### PR TITLE
Add an option to use CapsLock key

### DIFF
--- a/settings-inc.nsh
+++ b/settings-inc.nsh
@@ -17,26 +17,27 @@ Function createKeyPanelFunc
 	Pop $R0
 
 	nsArray::Clear keyPanel
-	${createKeyPanelButton} $R0 10u 26% 12u "Applications"
+	${createKeyPanelButton} $R0 10u 26% 11u "Caps Lock"
+	${createKeyPanelButton} $R1 10u 20% 11u "Scroll Lock"
+	${createKeyPanelButton} $R0 21u 26% 11u "Right Control"
+	${createKeyPanelButton} $R1 21u 20% 11u "Right Alt"
+	${createKeyPanelButton} $R0 32u 26% 11u "Right Windows"
+	${createKeyPanelButton} $R1 32u 20% 11u "Right Shift"
+	${createKeyPanelButton} $R0 43u 26% 11u "Left Control"
+	${createKeyPanelButton} $R1 43u 20% 11u "Left Alt"
+	${createKeyPanelButton} $R0 54u 26% 11u "Left Windows"
+	${createKeyPanelButton} $R1 54u 20% 11u "Left Shift"
+	${createKeyPanelButton} $R0 65u 26% 11u "Applications"
 	${NSD_AddStyle} $radioButton ${WS_GROUP}
 	ToolTips::Classic $radioButton 'Also popular as "Menu" and "Context Menu"'
-	${createKeyPanelButton} $R1 10u 20% 12u "Scroll Lock"
-	${createKeyPanelButton} $R0 22u 26% 12u "Right Control"
-	${createKeyPanelButton} $R1 22u 20% 12u "Right Alt"
-	${createKeyPanelButton} $R0 34u 26% 12u "Right Windows"
-	${createKeyPanelButton} $R1 34u 20% 12u "Right Shift"
-	${createKeyPanelButton} $R0 46u 26% 12u "Left Control"
-	${createKeyPanelButton} $R1 46u 20% 12u "Left Alt"
-	${createKeyPanelButton} $R0 58u 26% 12u "Left Windows"
-	${createKeyPanelButton} $R1 58u 20% 12u "Left Shift"
-	${createKeyPanelButton} $R0 70u 26% 12u "Pause/Break"
-	${createKeyPanelButton} $R1 70u 20% 12u "None"
+	${createKeyPanelButton} $R1 65u 20% 11u "Pause/Break"
+	${createKeyPanelButton} $R0 76u 26% 11u "None"
 
 	ReadRegStr $0 HKCU "Software\WkbLayout" "$R2"
 	${If} $0 == ""
 		StrCpy $R3 0
 	${Else}
-        	StrCpy $R3 ""
+		StrCpy $R3 ""
 
 		${ForEachIn} keyNameList $1 $2
 			${If} $0 == $2
@@ -66,10 +67,10 @@ FunctionEnd
 !define createKeyPanel `!insertmacro createKeyPanelMacro`
 
 Function wkbSettingsPage
-	nsArray::Split keyNameList "Apps|Scroll|RCtrl|RAlt|RWin|RShift|LCtrl|LAlt|LWin|LShift|Pause|00" "|"
+	nsArray::Split keyNameList "Caps|Scroll|RCtrl|RAlt|RWin|RShift|LCtrl|LAlt|LWin|LShift|Apps|Pause|00" "|"
 	nsDialogs::Create 1018
 
-	${NSD_CreateGroupBox} 0 0 49% 85u "Change layout key"
+	${NSD_CreateGroupBox} 0 0 49% 90u "Change layout key"
 	${createKeyPanel} 2% 28% "ToggleKey"
 	StrCpy $R0 "1"
 	${If} ${AtLeastWinVista}  # or 7even?
@@ -79,7 +80,7 @@ Function wkbSettingsPage
 	${IfThen} $0 == "1" ${|} ${NSD_SetFocus} $radioButton ${|}
 	${nsArray_Copy} keyPanel togglePanel
 
-	${NSD_CreateGroupBox} 51% 0 49% 85u "Shift-change key"
+	${NSD_CreateGroupBox} 51% 0 49% 90u "Shift-change key"
 	${createKeyPanel} 53% 79% "ShiftKey"
 	${nsArray_Copy} keyPanel shiftPanel
 	${ForEach} $R0 4 8 + 4
@@ -88,10 +89,10 @@ Function wkbSettingsPage
 		ToolTips::Classic $radioButton "Not recommended as a shift-change key"
 	${Next}
 
-	${NSD_CreateLabel} 0% 89u 99% 8u "Please select key(s) that will not be used for any regular functions"
-	${NSD_CreateHLine} 0 101u 100% 1u
+	${NSD_CreateLabel} 0 93u 99% 8u "Please select key(s) that will not be used for any regular functions"
+	${NSD_CreateHLine} 0 104u 100% 1u
 
-	${NSD_CreateCheckBox} 0 107u 99% 20u "Use the Scroll Lock led as a keyboard layout indicator$\n\
+	${NSD_CreateCheckBox} 0 107u 99% 23u "Use the Scroll Lock led as a keyboard layout indicator$\n\
 		Uncheck this if you use programs that rely on the Scroll Lock state (rare)"
 	Pop $ledLight
 	${NSD_AddStyle} $ledLight ${WS_GROUP}

--- a/wkb-mini.c
+++ b/wkb-mini.c
@@ -126,7 +126,7 @@ static BOOL shouldRetainRelease(DWORD key)
 static BOOL isLockLogout(BYTE key)
 {
 	return (key == 'L' && eitherPressed(VK_LWIN, VK_RWIN) && notModifiedExcept(VK_LWIN, VK_RWIN)) ||
-		/* Ctrl-Alt-Del with other shifts is unlikely, the check is 
+		/* Ctrl-Alt-Del with other shifts is unlikely, the check is
 		   too long, and there is no harm if Scroll blinks a bit. */
 		((key == VK_DELETE || key == VK_DECIMAL) && eitherPressed(VK_LMENU, VK_RMENU) &&
 		eitherPressed(VK_LCONTROL, VK_RCONTROL));
@@ -388,8 +388,7 @@ static unsigned translateKey(const char *str)
 		const char *name;
 	} keyNames[] =
 	{
-		{ VK_APPS, "Apps" },
-		{ VK_APPS, "Props" },  /* for compatibility */
+		{ VK_CAPITAL, "Caps" },
 		{ VK_SCROLL, "Scroll" },
 		{ VK_RCONTROL, "RCtrl" },
 		{ VK_RMENU, "RAlt" },
@@ -399,6 +398,8 @@ static unsigned translateKey(const char *str)
 		{ VK_LMENU, "LAlt" },
 		{ VK_LWIN, "LWin" },
 		{ VK_LSHIFT, "LShift" },
+		{ VK_APPS, "Apps" },
+		{ VK_APPS, "Props" },  /* for compatibility */
 		{ VK_PAUSE, "Pause" },
 		{ 0, NULL }
 	};


### PR DESCRIPTION
Hello! I decided to give wkb-mini a try and was a bit disappointed by the fact that there was no option to use my favourite key for layout switching, namely CapsLock. This pull request adds a corresponding option to the preferences dialog and its support in the program.

In order to fit the new option I had to shrink the contents of the preferences dialog (a little bit). Also, I took liberty of reordering options, putting CapsLock and ScrollLock options next to each other and Applications option closer to the bottom.
![settings-with-caps](https://cloud.githubusercontent.com/assets/52021/26529669/ef4ba5da-43cc-11e7-96ae-c844a867801b.png)
